### PR TITLE
Add repo and app documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ArcTecFox Monorepo
+
+This repository contains multiple applications that make up the ArcTecFox project. Each app lives inside the `apps/` directory and can be developed independently using npm workspaces.
+
+- **apps/lite** – Early access "PM Lite" version focused on the AI-powered planner and Excel export.
+- **apps/v1** – Full stack application with FastAPI backend and a React/Vite frontend.
+
+Install all dependencies by running the provided `setup_codex.sh` script. It sets up Python virtual environments and installs Node packages for both applications.
+
+See `package.json` for workspace scripts like `npm run dev:lite` or `npm run dev:v1` to start each app during development.
+

--- a/apps/v1/README.md
+++ b/apps/v1/README.md
@@ -1,0 +1,10 @@
+# ArcTecFox PM V1
+
+This directory contains the main ArcTecFox application.
+
+- `backend/` – FastAPI project providing the API.
+- `frontend/` – React app built with Vite and Tailwind CSS.
+- `supabase/` – Supabase configuration and scripts.
+
+Run `../../setup_codex.sh` from the repository root to install dependencies and create the required virtual environments.
+


### PR DESCRIPTION
## Summary
- document monorepo layout and setup script in `README.md`
- populate `apps/v1/README.md` with an overview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684f33eb59fc833397d7bcd90e406d76