### PR TITLE
Add global header layout

### DIFF
--- a/apps/lite/src/App.jsx
+++ b/apps/lite/src/App.jsx
@@ -1,13 +1,17 @@
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import PMPlanner from "./pages/PMPlanner";
+import Header from "./components/Header";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<PMPlanner />} />
-      </Routes>
-    </Router>
+    <>
+      <Header />
+      <Router>
+        <Routes>
+          <Route path="/" element={<PMPlanner />} />
+        </Routes>
+      </Router>
+    </>
   );
 }
 

--- a/apps/lite/src/components/Header.jsx
+++ b/apps/lite/src/components/Header.jsx
@@ -1,0 +1,6 @@
+const Header = () => (
+  <header className="bg-white shadow p-4">
+    <h1 className="text-xl font-bold text-gray-900">ArcTecFox</h1>
+  </header>
+);
+export default Header;

--- a/apps/v1/frontend/src/components/Header.jsx
+++ b/apps/v1/frontend/src/components/Header.jsx
@@ -1,0 +1,6 @@
+const Header = () => (
+  <header className="bg-white shadow p-4">
+    <h1 className="text-xl font-bold text-gray-900">ArcTecFox</h1>
+  </header>
+);
+export default Header;

--- a/apps/v1/frontend/src/layouts/MainLayout.jsx
+++ b/apps/v1/frontend/src/layouts/MainLayout.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { NavLink, Outlet, Link } from "react-router-dom";
 import { getCurrentUser, signOut } from "../api";
+import Header from "../components/Header";
 import { 
   BarChart3, 
   Settings, 
@@ -62,6 +63,7 @@ const MainLayout = () => {
         </header>
 
         <main className="flex-1 overflow-auto p-6">
+          <Header />
           <Outlet />
         </main>
       </div>


### PR DESCRIPTION
## Summary
- add `Header` component to Lite and v1
- show `Header` in `App.jsx` for Lite
- render `Header` above routed pages in v1 `MainLayout`

## Testing
- `npm run build:lite` *(fails: must not have multiple workspaces with the same name)*

------
https://chatgpt.com/codex/tasks/task_b_684f3f4955248333ba5448eedcd16b71