### PR TITLE
Share Tailwind palette

### DIFF
--- a/apps/lite/tailwind.config.js
+++ b/apps/lite/tailwind.config.js
@@ -1,19 +1,15 @@
 // frontend/tailwind.config.js
+const preset = require('../tailwind.preset.js')
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  presets: [preset],
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {
-      colors: {
-        primary:    "#1E3A8A",
-        secondary:  "#9333EA",
-        background: "#F3F4F6",
-        text:       "#111827",
-      },
-    },
+    extend: {},
   },
   plugins: [],
 }

--- a/apps/tailwind.preset.js
+++ b/apps/tailwind.preset.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1E3A8A',
+        secondary: '#9333EA',
+        background: '#F3F4F6',
+        text: '#111827',
+      },
+    },
+  },
+};

--- a/apps/v1/frontend/tailwind.config.js
+++ b/apps/v1/frontend/tailwind.config.js
@@ -1,19 +1,15 @@
 
+import preset from '../../tailwind.preset.js'
+
 /** @type {import('tailwindcss').Config} */
 export default {
+  presets: [preset],
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {
-      colors: {
-        primary: "#1E3A8A",
-        secondary: "#9333EA",
-        background: "#F3F4F6",
-        text: "#111827",
-      },
-    },
+    extend: {},
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extract common color palette into `apps/tailwind.preset.js`
- use the preset in Lite and v1 frontend Tailwind configs

## Testing
- `npm --workspace apps/lite run build` *(fails: vite not found)*
- `npm --workspace apps/v1 run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850df96a3048333935a29758773b18e